### PR TITLE
fix: Update spec to use string instead of enum for ProxyResponseTransform attributes

### DIFF
--- a/.openapi-generator/FILES
+++ b/.openapi-generator/FILES
@@ -69,8 +69,6 @@ docs/ProxiesApi.md
 docs/Proxy.md
 docs/ProxyPaginatedList.md
 docs/ProxyTransform.md
-docs/ProxyTransformMatcher.md
-docs/ProxyTransformType.md
 docs/ReactRequest.md
 docs/ReactResponse.md
 docs/Reactor.md
@@ -178,8 +176,6 @@ model_problem_details.go
 model_proxy.go
 model_proxy_paginated_list.go
 model_proxy_transform.go
-model_proxy_transform_matcher.go
-model_proxy_transform_type.go
 model_react_request.go
 model_react_response.go
 model_reactor.go

--- a/README.md
+++ b/README.md
@@ -202,8 +202,6 @@ Class | Method | HTTP request | Description
  - [Proxy](docs/Proxy.md)
  - [ProxyPaginatedList](docs/ProxyPaginatedList.md)
  - [ProxyTransform](docs/ProxyTransform.md)
- - [ProxyTransformMatcher](docs/ProxyTransformMatcher.md)
- - [ProxyTransformType](docs/ProxyTransformType.md)
  - [ReactRequest](docs/ReactRequest.md)
  - [ReactResponse](docs/ReactResponse.md)
  - [Reactor](docs/Reactor.md)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ go get golang.org/x/net/context
 Put the package under your project folder and add the following in import:
 
 ```golang
-import basistheory "github.com/Basis-Theory/basistheory-go/v5"
+import basistheory "github.com/Basis-Theory/basistheory-go/v6"
 ```
 
 To use a proxy, set the environment variable `HTTP_PROXY`:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3926,8 +3926,8 @@ components:
         response_transform:
           code: code
           expression: expression
-          type: null
-          matcher: null
+          type: type
+          matcher: matcher
           replacement: replacement
         application:
           tenant_id: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
@@ -4001,8 +4001,8 @@ components:
         request_transform:
           code: code
           expression: expression
-          type: null
-          matcher: null
+          type: type
+          matcher: matcher
           replacement: replacement
       properties:
         name:
@@ -4951,8 +4951,8 @@ components:
         response_transform:
           code: code
           expression: expression
-          type: null
-          matcher: null
+          type: type
+          matcher: matcher
           replacement: replacement
         response_reactor_id: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
         proxy_host: proxy_host
@@ -4963,8 +4963,8 @@ components:
         request_transform:
           code: code
           expression: expression
-          type: null
-          matcher: null
+          type: type
+          matcher: matcher
           replacement: replacement
         modified_at: 2000-01-23T04:56:07.000+00:00
         key: key
@@ -5072,8 +5072,8 @@ components:
           response_transform:
             code: code
             expression: expression
-            type: null
-            matcher: null
+            type: type
+            matcher: matcher
             replacement: replacement
           response_reactor_id: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
           proxy_host: proxy_host
@@ -5084,8 +5084,8 @@ components:
           request_transform:
             code: code
             expression: expression
-            type: null
-            matcher: null
+            type: type
+            matcher: matcher
             replacement: replacement
           modified_at: 2000-01-23T04:56:07.000+00:00
           key: key
@@ -5100,8 +5100,8 @@ components:
           response_transform:
             code: code
             expression: expression
-            type: null
-            matcher: null
+            type: type
+            matcher: matcher
             replacement: replacement
           response_reactor_id: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
           proxy_host: proxy_host
@@ -5112,8 +5112,8 @@ components:
           request_transform:
             code: code
             expression: expression
-            type: null
-            matcher: null
+            type: type
+            matcher: matcher
             replacement: replacement
           modified_at: 2000-01-23T04:56:07.000+00:00
           key: key
@@ -5128,8 +5128,8 @@ components:
           response_transform:
             code: code
             expression: expression
-            type: null
-            matcher: null
+            type: type
+            matcher: matcher
             replacement: replacement
           response_reactor_id: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
           proxy_host: proxy_host
@@ -5140,8 +5140,8 @@ components:
           request_transform:
             code: code
             expression: expression
-            type: null
-            matcher: null
+            type: type
+            matcher: matcher
             replacement: replacement
           modified_at: 2000-01-23T04:56:07.000+00:00
           key: key
@@ -5156,8 +5156,8 @@ components:
           response_transform:
             code: code
             expression: expression
-            type: null
-            matcher: null
+            type: type
+            matcher: matcher
             replacement: replacement
           response_reactor_id: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
           proxy_host: proxy_host
@@ -5168,8 +5168,8 @@ components:
           request_transform:
             code: code
             expression: expression
-            type: null
-            matcher: null
+            type: type
+            matcher: matcher
             replacement: replacement
           modified_at: 2000-01-23T04:56:07.000+00:00
           key: key
@@ -5184,8 +5184,8 @@ components:
           response_transform:
             code: code
             expression: expression
-            type: null
-            matcher: null
+            type: type
+            matcher: matcher
             replacement: replacement
           response_reactor_id: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
           proxy_host: proxy_host
@@ -5196,8 +5196,8 @@ components:
           request_transform:
             code: code
             expression: expression
-            type: null
-            matcher: null
+            type: type
+            matcher: matcher
             replacement: replacement
           modified_at: 2000-01-23T04:56:07.000+00:00
           key: key
@@ -5216,18 +5216,20 @@ components:
       example:
         code: code
         expression: expression
-        type: null
-        matcher: null
+        type: type
+        matcher: matcher
         replacement: replacement
       properties:
         type:
-          $ref: '#/components/schemas/ProxyTransformType'
+          nullable: true
+          type: string
         code:
           maxLength: 50000
           nullable: true
           type: string
         matcher:
-          $ref: '#/components/schemas/ProxyTransformMatcher'
+          nullable: true
+          type: string
         expression:
           nullable: true
           type: string
@@ -5235,16 +5237,6 @@ components:
           nullable: true
           type: string
       type: object
-    ProxyTransformMatcher:
-      enum:
-      - REGEX
-      - CHASE_STRATUS_PAN
-      type: string
-    ProxyTransformType:
-      enum:
-      - CODE
-      - MASK
-      type: string
     ReactRequest:
       additionalProperties: false
       example:
@@ -8579,8 +8571,8 @@ components:
         response_transform:
           code: code
           expression: expression
-          type: null
-          matcher: null
+          type: type
+          matcher: matcher
           replacement: replacement
         application:
           tenant_id: 046b6c7f-0b8a-43b9-b35d-6489e6daee91
@@ -8654,8 +8646,8 @@ components:
         request_transform:
           code: code
           expression: expression
-          type: null
-          matcher: null
+          type: type
+          matcher: matcher
           replacement: replacement
       properties:
         name:

--- a/docs/ProxyTransform.md
+++ b/docs/ProxyTransform.md
@@ -4,9 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Type** | Pointer to [**ProxyTransformType**](ProxyTransformType.md) |  | [optional] 
+**Type** | Pointer to **NullableString** |  | [optional] 
 **Code** | Pointer to **NullableString** |  | [optional] 
-**Matcher** | Pointer to [**ProxyTransformMatcher**](ProxyTransformMatcher.md) |  | [optional] 
+**Matcher** | Pointer to **NullableString** |  | [optional] 
 **Expression** | Pointer to **NullableString** |  | [optional] 
 **Replacement** | Pointer to **NullableString** |  | [optional] 
 
@@ -31,20 +31,20 @@ but it doesn't guarantee that properties required by API are set
 
 ### GetType
 
-`func (o *ProxyTransform) GetType() ProxyTransformType`
+`func (o *ProxyTransform) GetType() string`
 
 GetType returns the Type field if non-nil, zero value otherwise.
 
 ### GetTypeOk
 
-`func (o *ProxyTransform) GetTypeOk() (*ProxyTransformType, bool)`
+`func (o *ProxyTransform) GetTypeOk() (*string, bool)`
 
 GetTypeOk returns a tuple with the Type field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetType
 
-`func (o *ProxyTransform) SetType(v ProxyTransformType)`
+`func (o *ProxyTransform) SetType(v string)`
 
 SetType sets Type field to given value.
 
@@ -54,6 +54,16 @@ SetType sets Type field to given value.
 
 HasType returns a boolean if a field has been set.
 
+### SetTypeNil
+
+`func (o *ProxyTransform) SetTypeNil(b bool)`
+
+ SetTypeNil sets the value for Type to be an explicit nil
+
+### UnsetType
+`func (o *ProxyTransform) UnsetType()`
+
+UnsetType ensures that no value is present for Type, not even an explicit nil
 ### GetCode
 
 `func (o *ProxyTransform) GetCode() string`
@@ -91,20 +101,20 @@ HasCode returns a boolean if a field has been set.
 UnsetCode ensures that no value is present for Code, not even an explicit nil
 ### GetMatcher
 
-`func (o *ProxyTransform) GetMatcher() ProxyTransformMatcher`
+`func (o *ProxyTransform) GetMatcher() string`
 
 GetMatcher returns the Matcher field if non-nil, zero value otherwise.
 
 ### GetMatcherOk
 
-`func (o *ProxyTransform) GetMatcherOk() (*ProxyTransformMatcher, bool)`
+`func (o *ProxyTransform) GetMatcherOk() (*string, bool)`
 
 GetMatcherOk returns a tuple with the Matcher field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetMatcher
 
-`func (o *ProxyTransform) SetMatcher(v ProxyTransformMatcher)`
+`func (o *ProxyTransform) SetMatcher(v string)`
 
 SetMatcher sets Matcher field to given value.
 
@@ -114,6 +124,16 @@ SetMatcher sets Matcher field to given value.
 
 HasMatcher returns a boolean if a field has been set.
 
+### SetMatcherNil
+
+`func (o *ProxyTransform) SetMatcherNil(b bool)`
+
+ SetMatcherNil sets the value for Matcher to be an explicit nil
+
+### UnsetMatcher
+`func (o *ProxyTransform) UnsetMatcher()`
+
+UnsetMatcher ensures that no value is present for Matcher, not even an explicit nil
 ### GetExpression
 
 `func (o *ProxyTransform) GetExpression() string`

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Basis-Theory/basistheory-go/v5
+module github.com/Basis-Theory/basistheory-go/v6
 
 go 1.19
 

--- a/internal/testutils/setup.go
+++ b/internal/testutils/setup.go
@@ -2,7 +2,7 @@ package testutils
 
 import (
 	"context"
-	"github.com/Basis-Theory/basistheory-go/v5"
+	"github.com/Basis-Theory/basistheory-go/v6"
 	"github.com/joho/godotenv"
 	"os"
 	"strings"

--- a/model_proxy_transform.go
+++ b/model_proxy_transform.go
@@ -19,11 +19,11 @@ var _ MappedNullable = &ProxyTransform{}
 
 // ProxyTransform struct for ProxyTransform
 type ProxyTransform struct {
-	Type        *ProxyTransformType    `json:"type,omitempty"`
-	Code        NullableString         `json:"code,omitempty"`
-	Matcher     *ProxyTransformMatcher `json:"matcher,omitempty"`
-	Expression  NullableString         `json:"expression,omitempty"`
-	Replacement NullableString         `json:"replacement,omitempty"`
+	Type        NullableString `json:"type,omitempty"`
+	Code        NullableString `json:"code,omitempty"`
+	Matcher     NullableString `json:"matcher,omitempty"`
+	Expression  NullableString `json:"expression,omitempty"`
+	Replacement NullableString `json:"replacement,omitempty"`
 }
 
 // NewProxyTransform instantiates a new ProxyTransform object
@@ -43,22 +43,23 @@ func NewProxyTransformWithDefaults() *ProxyTransform {
 	return &this
 }
 
-// GetType returns the Type field value if set, zero value otherwise.
-func (o *ProxyTransform) GetType() ProxyTransformType {
-	if o == nil || IsNil(o.Type) {
-		var ret ProxyTransformType
+// GetType returns the Type field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *ProxyTransform) GetType() string {
+	if o == nil || IsNil(o.Type.Get()) {
+		var ret string
 		return ret
 	}
-	return *o.Type
+	return *o.Type.Get()
 }
 
 // GetTypeOk returns a tuple with the Type field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ProxyTransform) GetTypeOk() (*ProxyTransformType, bool) {
-	if o == nil || IsNil(o.Type) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ProxyTransform) GetTypeOk() (*string, bool) {
+	if o == nil {
 		return nil, false
 	}
-	return o.Type, true
+	return o.Type.Get(), o.Type.IsSet()
 }
 
 // HasType returns a boolean if a field is not nil.
@@ -70,9 +71,19 @@ func (o *ProxyTransform) HasType() bool {
 	return false
 }
 
-// SetType gets a reference to the given ProxyTransformType and assigns it to the Type field.
-func (o *ProxyTransform) SetType(v ProxyTransformType) {
-	o.Type = &v
+// SetType gets a reference to the given NullableString and assigns it to the Type field.
+func (o *ProxyTransform) SetType(v string) {
+	o.Type.Set(&v)
+}
+
+// SetTypeNil sets the value for Type to be an explicit nil
+func (o *ProxyTransform) SetTypeNil() {
+	o.Type.Set(nil)
+}
+
+// UnsetType ensures that no value is present for Type, not even an explicit nil
+func (o *ProxyTransform) UnsetType() {
+	o.Type.Unset()
 }
 
 // GetCode returns the Code field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -118,22 +129,23 @@ func (o *ProxyTransform) UnsetCode() {
 	o.Code.Unset()
 }
 
-// GetMatcher returns the Matcher field value if set, zero value otherwise.
-func (o *ProxyTransform) GetMatcher() ProxyTransformMatcher {
-	if o == nil || IsNil(o.Matcher) {
-		var ret ProxyTransformMatcher
+// GetMatcher returns the Matcher field value if set, zero value otherwise (both if not set or set to explicit null).
+func (o *ProxyTransform) GetMatcher() string {
+	if o == nil || IsNil(o.Matcher.Get()) {
+		var ret string
 		return ret
 	}
-	return *o.Matcher
+	return *o.Matcher.Get()
 }
 
 // GetMatcherOk returns a tuple with the Matcher field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *ProxyTransform) GetMatcherOk() (*ProxyTransformMatcher, bool) {
-	if o == nil || IsNil(o.Matcher) {
+// NOTE: If the value is an explicit nil, `nil, true` will be returned
+func (o *ProxyTransform) GetMatcherOk() (*string, bool) {
+	if o == nil {
 		return nil, false
 	}
-	return o.Matcher, true
+	return o.Matcher.Get(), o.Matcher.IsSet()
 }
 
 // HasMatcher returns a boolean if a field is not nil.
@@ -145,9 +157,19 @@ func (o *ProxyTransform) HasMatcher() bool {
 	return false
 }
 
-// SetMatcher gets a reference to the given ProxyTransformMatcher and assigns it to the Matcher field.
-func (o *ProxyTransform) SetMatcher(v ProxyTransformMatcher) {
-	o.Matcher = &v
+// SetMatcher gets a reference to the given NullableString and assigns it to the Matcher field.
+func (o *ProxyTransform) SetMatcher(v string) {
+	o.Matcher.Set(&v)
+}
+
+// SetMatcherNil sets the value for Matcher to be an explicit nil
+func (o *ProxyTransform) SetMatcherNil() {
+	o.Matcher.Set(nil)
+}
+
+// UnsetMatcher ensures that no value is present for Matcher, not even an explicit nil
+func (o *ProxyTransform) UnsetMatcher() {
+	o.Matcher.Unset()
 }
 
 // GetExpression returns the Expression field value if set, zero value otherwise (both if not set or set to explicit null).
@@ -246,14 +268,14 @@ func (o ProxyTransform) MarshalJSON() ([]byte, error) {
 
 func (o ProxyTransform) ToMap() (map[string]interface{}, error) {
 	toSerialize := map[string]interface{}{}
-	if !IsNil(o.Type) {
-		toSerialize["type"] = o.Type
+	if o.Type.IsSet() {
+		toSerialize["type"] = o.Type.Get()
 	}
 	if o.Code.IsSet() {
 		toSerialize["code"] = o.Code.Get()
 	}
-	if !IsNil(o.Matcher) {
-		toSerialize["matcher"] = o.Matcher
+	if o.Matcher.IsSet() {
+		toSerialize["matcher"] = o.Matcher.Get()
 	}
 	if o.Expression.IsSet() {
 		toSerialize["expression"] = o.Expression.Get()

--- a/swagger.json
+++ b/swagger.json
@@ -5844,7 +5844,8 @@
         "type": "object",
         "properties": {
           "type": {
-            "$ref": "#/components/schemas/ProxyTransformType"
+            "type": "string",
+            "nullable": true
           },
           "code": {
             "maxLength": 50000,
@@ -5852,7 +5853,8 @@
             "nullable": true
           },
           "matcher": {
-            "$ref": "#/components/schemas/ProxyTransformMatcher"
+            "type": "string",
+            "nullable": true
           },
           "expression": {
             "type": "string",
@@ -5864,20 +5866,6 @@
           }
         },
         "additionalProperties": false
-      },
-      "ProxyTransformMatcher": {
-        "enum": [
-          "REGEX",
-          "CHASE_STRATUS_PAN"
-        ],
-        "type": "string"
-      },
-      "ProxyTransformType": {
-        "enum": [
-          "CODE",
-          "MASK"
-        ],
-        "type": "string"
       },
       "ReactRequest": {
         "type": "object",

--- a/tests/api_applications_test.go
+++ b/tests/api_applications_test.go
@@ -2,8 +2,8 @@ package basistheory_test
 
 import (
 	"context"
-	"github.com/Basis-Theory/basistheory-go/v5"
-	"github.com/Basis-Theory/basistheory-go/v5/internal/testutils"
+	"github.com/Basis-Theory/basistheory-go/v6"
+	"github.com/Basis-Theory/basistheory-go/v6/internal/testutils"
 	"testing"
 )
 

--- a/tests/api_permissions_test.go
+++ b/tests/api_permissions_test.go
@@ -1,7 +1,7 @@
 package basistheory_test
 
 import (
-	"github.com/Basis-Theory/basistheory-go/v5/internal/testutils"
+	"github.com/Basis-Theory/basistheory-go/v6/internal/testutils"
 	"testing"
 )
 

--- a/tests/api_proxies_test.go
+++ b/tests/api_proxies_test.go
@@ -1,8 +1,8 @@
 package basistheory_test
 
 import (
-	"github.com/Basis-Theory/basistheory-go/v5"
-	"github.com/Basis-Theory/basistheory-go/v5/internal/testutils"
+	"github.com/Basis-Theory/basistheory-go/v6"
+	"github.com/Basis-Theory/basistheory-go/v6/internal/testutils"
 	"testing"
 )
 

--- a/tests/api_reactors_test.go
+++ b/tests/api_reactors_test.go
@@ -1,8 +1,8 @@
 package basistheory_test
 
 import (
-	"github.com/Basis-Theory/basistheory-go/v5"
-	"github.com/Basis-Theory/basistheory-go/v5/internal/testutils"
+	"github.com/Basis-Theory/basistheory-go/v6"
+	"github.com/Basis-Theory/basistheory-go/v6/internal/testutils"
 	"testing"
 )
 

--- a/tests/api_tenants_test.go
+++ b/tests/api_tenants_test.go
@@ -1,8 +1,8 @@
 package basistheory_test
 
 import (
-	"github.com/Basis-Theory/basistheory-go/v5"
-	"github.com/Basis-Theory/basistheory-go/v5/internal/testutils"
+	"github.com/Basis-Theory/basistheory-go/v6"
+	"github.com/Basis-Theory/basistheory-go/v6/internal/testutils"
 	"testing"
 )
 

--- a/tests/api_tokenize_test.go
+++ b/tests/api_tokenize_test.go
@@ -1,8 +1,8 @@
 package basistheory_test
 
 import (
-	"github.com/Basis-Theory/basistheory-go/v5"
-	"github.com/Basis-Theory/basistheory-go/v5/internal/testutils"
+	"github.com/Basis-Theory/basistheory-go/v6"
+	"github.com/Basis-Theory/basistheory-go/v6/internal/testutils"
 	"testing"
 )
 

--- a/tests/api_tokens_test.go
+++ b/tests/api_tokens_test.go
@@ -2,8 +2,8 @@ package basistheory_test
 
 import (
 	"fmt"
-	"github.com/Basis-Theory/basistheory-go/v5"
-	"github.com/Basis-Theory/basistheory-go/v5/internal/testutils"
+	"github.com/Basis-Theory/basistheory-go/v6"
+	"github.com/Basis-Theory/basistheory-go/v6/internal/testutils"
 	"testing"
 )
 


### PR DESCRIPTION
<!-- Describe your changes in detail -->
## Description

- Updates based on change from enum to string (Humanize) enums for proxy response transforms.

<!-- Please describe in detail how teammates can test your changes. -->
## Testing required outside of automated testing?

- [ ] Not Applicable

<!-- Provide Screenshots when applicable -->
### Screenshots (if appropriate):

- [ ] Not Applicable

<!-- Describe Rollback or Rollforward Procedure -->
## Rollback / Rollforward Procedure

- [ ] Roll Forward
- [ ] Roll Back

## Reviewer Checklist

- [ ] Description of Change
- [ ] Description of outside testing if applicable.
- [ ] Description of Roll Forward / Backward Procedure
- [ ] Documentation updated for Change
